### PR TITLE
Antlr build fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ class BuildPyWithGenerateCommand(setuptools.command.build_py.build_py):
 
     def gen(self):
         cmds = [
-            'java -jar vendor/antlr-4.11.1-complete.jar -Dlanguage=Python3 src/solidity_parser/grammar/v060/Solidity.g4 -o src/solidity_parser/grammar/v060/',
-            'java -jar vendor/antlr-4.11.1-complete.jar -Dlanguage=Python3 src/solidity_parser/grammar/v070/Solidity.g4 -o src/solidity_parser/grammar/v070/',
+            'java -jar vendor/antlr-4.11.1-complete.jar -Dlanguage=Python3 src/solidity_parser/grammar/v060/Solidity.g4 -o src/solidity_parser/grammar/v060/ -Xexact-output-dir',
+            'java -jar vendor/antlr-4.11.1-complete.jar -Dlanguage=Python3 src/solidity_parser/grammar/v070/Solidity.g4 -o src/solidity_parser/grammar/v070/ -Xexact-output-dir',
             'java -jar vendor/antlr-4.11.1-complete.jar -Dlanguage=Python3 src/solidity_parser/grammar/v080/SolidityParser.g4 src/solidity_parser/grammar/v080/SolidityLexer.g4 -o src/solidity_parser/grammar/v080/ -Xexact-output-dir',
             'java -jar vendor/antlr-4.11.1-complete.jar -Dlanguage=Python3 src/solidity_parser/grammar/v088/SolidityParser.g4 src/solidity_parser/grammar/v088/SolidityLexer.g4 -o src/solidity_parser/grammar/v088/ -Xexact-output-dir' ]
 


### PR DESCRIPTION
for some reason when antlr has multiple input files the output dir appears to be relative to the top dir of the input files. this was resulting in generated files getting written to 
`src/solidity_parser/grammar/v080/src/solidity_parser/grammar/v080/SolidityLexer.tokens`
instead of
`src/solidity_parser/grammar/v080/SolidityLexer.tokens`

Use -Xexact-output-dir to tell antlr to not infer output filename paths.

Use a setuptools hook so our generation code gets run in `pip` and `setuptools`.